### PR TITLE
added support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.6.14-alpine
+
+RUN pip install archerysec-cli
+
+CMD ["archerysec-cli"]


### PR DESCRIPTION
## Why is this important?

ArcherySec CLI is needed in DevSecOps pipelines to push reports from pipelines. Since most of clients are now running pipelines on Kubernetes based envs, therefore, they need slave container which has archerysec-cli installed in it. 

## What does this implement?

I've added Dockerfile, which can be used to build docker image and push to official repo on dockerhub.

For eg: https://hub.docker.com/repository/docker/sourabh385/archerysec-cli

